### PR TITLE
XIVY-1120 in JIRA we use short version like 11.1 instead of 11.1.0

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/jira/release/NewReleaseVersionMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/jira/release/NewReleaseVersionMojo.java
@@ -52,8 +52,8 @@ public class NewReleaseVersionMojo extends AbstractMojo {
       return;
     }
 
-    var next = ReleaseVersion.parse(newVersion);
-    if (next.isEmpty()) {
+    var version = ReleaseVersion.parse(newVersion);
+    if (version.isEmpty()) {
       getLog().error("aborting: property 'newVersion' is mandatory, but was "+newVersion);
       return;
     }
@@ -64,27 +64,26 @@ public class NewReleaseVersionMojo extends AbstractMojo {
     var after = ReleaseVersion.parse(afterVersion);
 
     var releases = new JiraReleaseService(server, jiraServerUri);
-    createVersion(releases, newVersion, after, getLog());
+    createVersion(releases, version.get(), after, getLog());
   }
 
-  private static void createVersion(JiraReleaseService releases, String newVersion, Optional<String> afterVersion, Log log) {
+  private static void createVersion(JiraReleaseService releases, ReleaseVersion newVersion, Optional<ReleaseVersion> afterVersion, Log log) {
     var versions = releases.ivyVersions();
     var existing = versions.stream()
-      .filter(version -> newVersion.equalsIgnoreCase(version.name))
+      .filter(version -> newVersion.toShortString().equalsIgnoreCase(version.name))
       .findFirst();
     if (existing.isPresent()) {
-      log.info("skipping: XIVY version "+newVersion+" exists already "+existing.get().self);
+      log.info("Skipping: XIVY version "+newVersion+" exists already "+existing.get().self);
       return;
     }
 
-    JiraVersion created = releases.create(newVersion);
-    log.info("created new XIVY version "+created.self);
+    JiraVersion created = releases.create(newVersion.toShortString());
+    log.info("Created new XIVY version " + created.self);
 
 
     if (afterVersion.isPresent()) {
-      releases.move(newVersion, afterVersion.get());
-      log.info("moved "+newVersion+" to occur after "+afterVersion);
+      releases.move(newVersion.toShortString(), afterVersion.get().toShortString());
+      log.info("Moved "+newVersion+" to occur after "+afterVersion);
     }
   }
-
 }

--- a/src/main/java/ch/ivyteam/ivy/jira/release/ReleaseVersion.java
+++ b/src/main/java/ch/ivyteam/ivy/jira/release/ReleaseVersion.java
@@ -4,19 +4,73 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 public class ReleaseVersion {
 
-  private static final Pattern VERSION = Pattern.compile("[0-9]+\\.[0-9]+\\.[0-9]+");
+  private static final Pattern VERSION = Pattern.compile("([0-9]+)\\.([0-9]+)\\.([0-9]+)");
+  private int major;
+  private int minor;
+  private int service;
 
-  public static Optional<String> parse(String version) {
+  public ReleaseVersion(int major, int minor, int service) {
+    if (major < 0 || minor < 0 || service < 0) {
+      throw new IllegalArgumentException("Major, minor and service need to be greater than 0");
+    }
+    this.major = major;
+    this.minor = minor;
+    this.service = service;
+  }
+
+  public static Optional<ReleaseVersion> parse(String version) {
     if (version == null) {
       return Optional.empty();
     }
     Matcher matcher = VERSION.matcher(version);
     if (matcher.find()) {
-      return Optional.of(matcher.group());
+      var major = Integer.parseInt(matcher.group(1));
+      var minor = Integer.parseInt(matcher.group(2));
+      var service = Integer.parseInt(matcher.group(3));
+      return Optional.of(new ReleaseVersion(major, minor, service));
     }
     return Optional.empty();
   }
 
+  String toShortString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(major).append('.').append(minor);
+    if (service != 0) {
+      builder.append('.');
+      builder.append(service);
+    }
+    return builder.toString();
+  }
+
+  @Override
+  public String toString() {
+    return major + "." + minor + "." + service;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != ReleaseVersion.class) {
+      return false;
+    }
+    var other = (ReleaseVersion)obj;
+    return major == other.major &&
+           minor == other.minor &&
+           service == other.service;
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(major)
+        .append(minor)
+        .append(service)
+        .toHashCode();
+  }
 }

--- a/src/test/java/ch/ivyteam/ivy/jira/release/TestReleaseVersion.java
+++ b/src/test/java/ch/ivyteam/ivy/jira/release/TestReleaseVersion.java
@@ -9,7 +9,7 @@ class TestReleaseVersion {
 
   @Test
   void valid() {
-    assertThat(parse("9.1.0").get()).isEqualTo("9.1.0");
+    assertThat(parse("9.1.0").get()).isEqualTo(new ReleaseVersion(9, 1, 0));
   }
 
   @Test
@@ -21,11 +21,29 @@ class TestReleaseVersion {
 
   @Test
   void cutSnapshot() {
-    assertThat(parse("1.3.0-SNAPSHOT").get()).isEqualTo("1.3.0");
+    assertThat(parse("1.3.0-SNAPSHOT").get()).isEqualTo(new ReleaseVersion(1, 3, 0));
   }
 
   @Test
   void tooShort() {
     assertThat(parse("1.3")).isEmpty();
+  }
+
+  @Test
+  void tooLong() {
+    assertThat(parse("1.3.5.9").get()).isEqualTo(new ReleaseVersion(1,3,5));
+  }
+
+  @Test
+  void string() {
+    assertThat(new ReleaseVersion(1,3,1).toString()).isEqualTo("1.3.1");
+    assertThat(new ReleaseVersion(1,3,0).toString()).isEqualTo("1.3.0");
+  }
+
+  @Test
+  void toShortString() {
+    assertThat(new ReleaseVersion(1,3,1).toShortString()).isEqualTo("1.3.1");
+    assertThat(new ReleaseVersion(1,3,0).toShortString()).isEqualTo("1.3");
+    assertThat(new ReleaseVersion(1,0,0).toShortString()).isEqualTo("1.0");
   }
 }


### PR DESCRIPTION
Fix that we do not use third service version if it is 0 in JIRA. Instead of 11.1.0 we use 11.1. The same is not true for the minor version. There we use it. E.g., 10.0 instead of 10.